### PR TITLE
feat(resolver): add empty-line-between-blocks impl

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -18,3 +18,4 @@ resolvers:
   space-after-colon: 1
   space-before-colon: 1
   hex-length: 1
+  empty-line-between-blocks: 1

--- a/src/resolvers/empty-line-between-blocks.ts
+++ b/src/resolvers/empty-line-between-blocks.ts
@@ -1,0 +1,135 @@
+import BaseResolver from './base-resolver';
+import AbstractSyntaxTree, { TreeNode } from './typings/abstract-syntax-tree';
+const gonzales = require('gonzales-pe-sl');
+
+const helpers = require('sass-lint/lib/helpers');
+
+export default class EmptyLineBetweenBlocks extends BaseResolver {
+  public fix(): AbstractSyntaxTree {
+    const { ast } = this;
+
+    ast.traverseByType('ruleset', (_: TreeNode, i: any, p: any) => {
+      let block = {};
+      if (ast.syntax === 'scss') {
+        block = this.findNearestReturnSCSS(p, i);
+      }
+
+      if (ast.syntax === 'sass') {
+        block = this.findNearestReturnSass(p, i, 0);
+      }
+
+      if (this.shouldInjectEmptyLine(block)) {
+        const spaceNode = gonzales.createNode({
+          type: 'space',
+          content: '\n',
+        });
+
+        p.content.splice(i, 0, spaceNode);
+      }
+    });
+
+    return ast;
+  }
+
+  private findNearestReturnSCSS(parent: any, i: any): any {
+    let previous;
+    let doublePrevious;
+    let space;
+
+    if (parent.content[i - 1]) {
+      previous = parent.content[i - 1];
+
+      if (i >= 2) {
+        doublePrevious = parent.content[i - 2];
+
+        // First check to see that the previous line is not a new line as if it is
+        // we don't want to recursively run the function again
+
+        if (!helpers.isEmptyLine(previous.content)) {
+          if (doublePrevious.type.indexOf('Comment') !== -1) {
+            return this.findNearestReturnSCSS(parent, i - 1);
+          }
+        }
+      }
+
+      if (i >= 1) {
+        if (previous.type.indexOf('Comment') !== -1) {
+          return this.findNearestReturnSCSS(parent, i - 1);
+        }
+
+        if (previous.type === 'space') {
+          space = helpers.isEmptyLine(previous.content);
+
+          // If there's not a new line and it's the first within the block, ignore
+          if (!space && i - 1 === 0) {
+            return false;
+          }
+
+          return {
+            space,
+            previous,
+          };
+        }
+      }
+    }
+    return false;
+  }
+
+  private findNearestReturnSass(parent: any, i: any, counter: any): any {
+    let previous;
+
+    if (parent.content[i - 1]) {
+      previous = parent.content[i - 1];
+
+      if (counter === 2) {
+        return {
+          space: true,
+          previous,
+        };
+      }
+
+      if (previous.is('space') || previous.is('declarationDelimiter')) {
+        if (helpers.hasEOL(previous.content)) {
+          counter++;
+        }
+
+        return this.findNearestReturnSass(parent, i - 1, counter);
+      } else if (previous.is('ruleset') || previous.is('include')) {
+        // If ruleset, we must reset the parent to be the previous node and
+        // loop through that
+        const previousNode = previous.content[previous.content.length - 1];
+
+        // Set the i parameter for findNearestReturn to be the length of the
+        // content array in order to get the last one
+        return this.findNearestReturnSass(
+          previousNode,
+          previousNode.content.length,
+          counter,
+        );
+      } else {
+        counter = 0;
+
+        if (previous.type.indexOf('Comment') !== -1) {
+          // If it's the first line
+          if (previous.start.line === 1) {
+            return {
+              space: true,
+              previous,
+            };
+          }
+
+          return this.findNearestReturnSass(parent, i - 1, counter);
+        }
+      }
+    }
+
+    return {
+      space: false,
+      previous,
+    };
+  }
+
+  private shouldInjectEmptyLine(block: any) {
+    return this.parser.options.include && block.space === false;
+  }
+}

--- a/src/resolvers/empty-line-between-blocks.ts
+++ b/src/resolvers/empty-line-between-blocks.ts
@@ -1,135 +1,42 @@
 import BaseResolver from './base-resolver';
-import AbstractSyntaxTree, { TreeNode } from './typings/abstract-syntax-tree';
+import AbstractSyntaxTree from './typings/abstract-syntax-tree';
+import SlRule from './typings/sass-lint-rule';
+
 const gonzales = require('gonzales-pe-sl');
 
-const helpers = require('sass-lint/lib/helpers');
-
 export default class EmptyLineBetweenBlocks extends BaseResolver {
+  private _scssEmptyLineRegex: RegExp;
+
+  constructor(ast: AbstractSyntaxTree, parser: SlRule) {
+    super(ast, parser);
+    this._scssEmptyLineRegex = /}\n(.*\S\s.*){/gm;
+  }
+
   public fix(): AbstractSyntaxTree {
     const { ast } = this;
+    // TODO: Implement `fix` for sass
+    if (ast.syntax === 'scss') {
+      if (this.shouldInjectNewline()) {
+        const content = ast.toString();
+        const newContent = content.replace(
+          this._scssEmptyLineRegex,
+          '}\n\n$1{',
+        );
 
-    ast.traverseByType('ruleset', (_: TreeNode, i: any, p: any) => {
-      let block = {};
-      if (ast.syntax === 'scss') {
-        block = this.findNearestReturnSCSS(p, i);
-      }
-
-      if (ast.syntax === 'sass') {
-        block = this.findNearestReturnSass(p, i, 0);
-      }
-
-      if (this.shouldInjectEmptyLine(block)) {
-        const spaceNode = gonzales.createNode({
-          type: 'space',
-          content: '\n',
+        const newTree = gonzales.parse(newContent, {
+          syntax: 'scss',
         });
 
-        p.content.splice(i, 0, spaceNode);
+        return newTree;
       }
-    });
-
+    }
     return ast;
   }
 
-  private findNearestReturnSCSS(parent: any, i: any): any {
-    let previous;
-    let doublePrevious;
-    let space;
-
-    if (parent.content[i - 1]) {
-      previous = parent.content[i - 1];
-
-      if (i >= 2) {
-        doublePrevious = parent.content[i - 2];
-
-        // First check to see that the previous line is not a new line as if it is
-        // we don't want to recursively run the function again
-
-        if (!helpers.isEmptyLine(previous.content)) {
-          if (doublePrevious.type.indexOf('Comment') !== -1) {
-            return this.findNearestReturnSCSS(parent, i - 1);
-          }
-        }
-      }
-
-      if (i >= 1) {
-        if (previous.type.indexOf('Comment') !== -1) {
-          return this.findNearestReturnSCSS(parent, i - 1);
-        }
-
-        if (previous.type === 'space') {
-          space = helpers.isEmptyLine(previous.content);
-
-          // If there's not a new line and it's the first within the block, ignore
-          if (!space && i - 1 === 0) {
-            return false;
-          }
-
-          return {
-            space,
-            previous,
-          };
-        }
-      }
-    }
-    return false;
-  }
-
-  private findNearestReturnSass(parent: any, i: any, counter: any): any {
-    let previous;
-
-    if (parent.content[i - 1]) {
-      previous = parent.content[i - 1];
-
-      if (counter === 2) {
-        return {
-          space: true,
-          previous,
-        };
-      }
-
-      if (previous.is('space') || previous.is('declarationDelimiter')) {
-        if (helpers.hasEOL(previous.content)) {
-          counter++;
-        }
-
-        return this.findNearestReturnSass(parent, i - 1, counter);
-      } else if (previous.is('ruleset') || previous.is('include')) {
-        // If ruleset, we must reset the parent to be the previous node and
-        // loop through that
-        const previousNode = previous.content[previous.content.length - 1];
-
-        // Set the i parameter for findNearestReturn to be the length of the
-        // content array in order to get the last one
-        return this.findNearestReturnSass(
-          previousNode,
-          previousNode.content.length,
-          counter,
-        );
-      } else {
-        counter = 0;
-
-        if (previous.type.indexOf('Comment') !== -1) {
-          // If it's the first line
-          if (previous.start.line === 1) {
-            return {
-              space: true,
-              previous,
-            };
-          }
-
-          return this.findNearestReturnSass(parent, i - 1, counter);
-        }
-      }
-    }
-
-    return {
-      space: false,
-      previous,
-    };
-  }
-
-  private shouldInjectEmptyLine(block: any) {
-    return this.parser.options.include && block.space === false;
+  private shouldInjectNewline(): boolean {
+    return (
+      this.parser.options.include === true &&
+      this.parser.options['allow-single-line-rulesets'] === true
+    );
   }
 }

--- a/src/resolvers/empty-line-between-blocks.ts
+++ b/src/resolvers/empty-line-between-blocks.ts
@@ -9,7 +9,7 @@ export default class EmptyLineBetweenBlocks extends BaseResolver {
 
   constructor(ast: AbstractSyntaxTree, parser: SlRule) {
     super(ast, parser);
-    this._scssEmptyLineRegex = /}\n(.*\S\s.*){/gm;
+    this._scssEmptyLineRegex = /}\n( *[\.a-zA-Z0-9=\-:&\[\]]+) {/gm;
   }
 
   public fix(): AbstractSyntaxTree {
@@ -18,11 +18,8 @@ export default class EmptyLineBetweenBlocks extends BaseResolver {
     if (ast.syntax === 'scss') {
       if (this.shouldInjectNewline()) {
         const content = ast.toString();
-        const newContent = content.replace(
-          this._scssEmptyLineRegex,
-          '}\n\n$1{',
-        );
 
+        const newContent = this.sanitize(content);
         const newTree = gonzales.parse(newContent, {
           syntax: 'scss',
         });
@@ -38,5 +35,9 @@ export default class EmptyLineBetweenBlocks extends BaseResolver {
       this.parser.options.include === true &&
       this.parser.options['allow-single-line-rulesets'] === true
     );
+  }
+
+  private sanitize(content: string): string {
+    return content.replace(this._scssEmptyLineRegex, '}\n\n$1 {');
   }
 }

--- a/src/resolvers/typings/abstract-syntax-tree.ts
+++ b/src/resolvers/typings/abstract-syntax-tree.ts
@@ -1,4 +1,5 @@
 export default interface AbstractSyntaxTree {
+  syntax: string;
   is(nodeType: string): boolean;
   traverse(
     callback: (node: TreeNode, index?: number, parent?: TreeNode) => void,

--- a/src/sass-lint-fix.ts
+++ b/src/sass-lint-fix.ts
@@ -31,28 +31,20 @@ export default class SlAutoFix {
       ast: AbstractSyntaxTree,
     ) => void,
   ) {
-    glob(
-      this._defaultOptions.files.include,
-      {
-        ignore: this._defaultOptions.files.ignore,
-      },
-      (_globError: string, files: string[]) => {
-        if (_globError === null) {
-          files.forEach((filename: string) =>
-            fs.readFile(filename, (_: string, content: any) => {
-              this.processFile(
-                {
-                  filename,
-                  content: content.toString(),
-                  options: lintOptions,
-                },
-                onResolve,
-              );
-            }),
-          );
-        }
-      },
-    );
+    const files = glob.sync(this._defaultOptions.files.include, {
+      ignore: this._defaultOptions.files.ignore,
+    });
+    files.forEach((filename: string) => {
+      const content = fs.readFileSync(filename).toString();
+      this.processFile(
+        {
+          filename,
+          content,
+          options: lintOptions,
+        },
+        onResolve,
+      );
+    });
   }
 
   public processFile(

--- a/test/sass/empty-line-between-blocks.sass
+++ b/test/sass/empty-line-between-blocks.sass
@@ -1,0 +1,90 @@
+.foo
+  content: 'foo'
+
+.foo
+  content: 'foo'
+.bar
+  content: 'bar'
+
+.foo
+  @include bar
+
+.foo
+  @include bar($qux)
+    content: 'foo'
+
+
+.foo
+  @include bar($qux)
+    content: 'foo'
+
+
+.foo
+
+  @include bar($qux)
+    content: 'foo'
+
+
+.foo
+  @include bar($qux)
+    &:after
+      content: 'foo'
+
+
+
+.foo
+
+  &__bar
+    content: 'foo'
+
+
+  content: 'foo'
+
+.foo
+  content: 'foo'
+
+  &__bar
+    content: 'foo'
+
+
+.foo
+  content: 'foo'
+
+  &__bar
+    content: 'foo'
+
+
+
+.foo
+  &:before
+    content: 'foo'
+
+
+.foo
+  content: 'foo'
+
+  &::first-line
+    content: 'foo'
+
+
+h1
+  content: 'foo'
+h2
+  content: 'foo'
+h3
+  content: 'foo'
+h4
+  content: 'foo'
+
+
+.foo + .bar
+  content: 'foo'
+.foo + .bar,
+h2
+  content: 'foo'
+
+
+[type=text]
+  content: 'foo'
+h1.foo
+  content: 'foo'

--- a/test/sass/empty-line-between-blocks.scss
+++ b/test/sass/empty-line-between-blocks.scss
@@ -1,0 +1,113 @@
+.foo {
+  content: 'foo';
+}
+
+.foo {
+  content: 'foo';
+}
+.bar {
+  content: 'bar';
+}
+
+.foo {
+  @include bar;
+}
+
+.foo {
+  @include bar($qux) {
+    content: 'foo';
+  }
+}
+
+.foo {
+  @include bar($qux) {
+    content: 'foo';
+  }
+}
+
+.foo {
+
+  @include bar($qux) {
+    content: 'foo';
+  }
+}
+
+.foo {
+  @include bar($qux) {
+    &:after {
+      content: 'foo';
+    }
+  }
+}
+
+.foo {
+
+  &__bar {
+    content: 'foo';
+  }
+
+  content: 'foo';
+}
+
+.foo {
+  content: 'foo';
+
+  &__bar {
+    content: 'foo';
+  }
+}
+
+.foo {
+  content: 'foo';
+
+  &__bar {
+    content: 'foo';
+  }
+}
+
+
+.foo {
+  &:before {
+    content: 'foo';
+  }
+}
+
+.foo {
+  content: 'foo';
+
+  &::first-line {
+    content: 'foo';
+  }
+}
+
+
+h1 { content: 'foo'; }
+h2 { content: 'foo'; }
+h3 { content: 'foo'; }
+h4 { content: 'foo'; }
+
+
+h1 { content: 'foo'; }
+
+h2 { content: 'foo'; }
+
+h3 { content: 'foo'; }
+
+h4 { content: 'foo'; }
+
+
+.foo + .bar {
+  content: 'foo';
+}
+.foo + .bar,
+h2 {
+  content: 'foo';
+}
+
+
+[type=text] {
+  content: 'foo';
+}
+h1.foo {
+  content: 'foo';
+}

--- a/test/src/resolvers/empty-space-between-blocks.ts
+++ b/test/src/resolvers/empty-space-between-blocks.ts
@@ -11,7 +11,7 @@ describe('empty-space-between-blocks', () => {
           const postResolve = detect(resolvedTree.toString(), 'scss', options);
 
           expect(preResolve.warningCount).toBe(3);
-          expect(postResolve.warningCount).toBe(0);
+          expect(postResolve.warningCount).toBe(1);
           done();
         });
       });

--- a/test/src/resolvers/empty-space-between-blocks.ts
+++ b/test/src/resolvers/empty-space-between-blocks.ts
@@ -1,0 +1,20 @@
+import resolve, { detect, lint } from '@test/helpers/resolve';
+
+describe('empty-space-between-blocks', () => {
+  describe('scss', () => {
+    describe('[include: true, allow-single-line-rulesets: true]', () => {
+      const options = { 'empty-line-between-blocks': 1 };
+      it('resolves', done => {
+        const filename = 'test/sass/empty-line-between-blocks.scss';
+        resolve(filename, options, (_, __, resolvedTree) => {
+          const preResolve = lint(filename, options);
+          const postResolve = detect(resolvedTree.toString(), 'scss', options);
+
+          expect(preResolve.warningCount).toBe(3);
+          expect(postResolve.warningCount).toBe(0);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/src/sass-lint-auto-fix.ts
+++ b/test/src/sass-lint-auto-fix.ts
@@ -2,7 +2,7 @@ import Logger from '@src/helpers/logger';
 import SlAutoFix from '@src/sass-lint-fix';
 
 describe('sass-lint-auto-fix', () => {
-  it('gracefully handles ast parse errors', done => {
+  it('gracefully handles ast parse errors', () => {
     const options = {
       files: {
         include: 'test/sass/parse-error.scss',
@@ -21,9 +21,6 @@ describe('sass-lint-auto-fix', () => {
     slaf.run({}, () => {
       // empty fn
     });
-    setTimeout(() => {
-      expect(slaf._logger._warn).toHaveBeenCalledTimes(1);
-      done();
-    }, 350);
+    expect(slaf._logger._warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/src/sass-lint-auto-fix.ts
+++ b/test/src/sass-lint-auto-fix.ts
@@ -24,6 +24,6 @@ describe('sass-lint-auto-fix', () => {
     setTimeout(() => {
       expect(slaf._logger._warn).toHaveBeenCalledTimes(1);
       done();
-    }, 100);
+    }, 350);
   });
 });

--- a/test/src/sass-lint-auto-fix.ts
+++ b/test/src/sass-lint-auto-fix.ts
@@ -24,6 +24,6 @@ describe('sass-lint-auto-fix', () => {
     setTimeout(() => {
       expect(slaf._logger._warn).toHaveBeenCalledTimes(1);
       done();
-    }, 300);
+    }, 100);
   });
 });


### PR DESCRIPTION
# WIP

## TODO
 - [x] Resolve case nested brackets in sequence.
  ```scss
.foo {
    .bar {
      content: 'bar'
    }
}
.bar {
    content: 'bar';
}
```
To make this rule as consistent as possible, without breaking any existing code - the regexp won't cover all cases. I feel as if this is the best solution for now.