### PR TITLE
Feat/indentation - wip

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -23,3 +23,4 @@ resolvers:
   url-quotes: 1
   zero-unit: 1
   hex-notation: 1
+  indentation: 0

--- a/src/resolvers/indentation.ts
+++ b/src/resolvers/indentation.ts
@@ -91,7 +91,7 @@ export default class Indentation extends BaseResolver {
     }
   }
 
-  private blockStillOpen(line) {
+  private blockStillOpen(line: string) {
     return !line.trimRight().endsWith('}');
   }
 

--- a/src/resolvers/indentation.ts
+++ b/src/resolvers/indentation.ts
@@ -1,6 +1,5 @@
-import { truncate } from 'fs';
 import BaseResolver from './base-resolver';
-import AbstractSyntaxTree, { TreeNode } from './typings/abstract-syntax-tree';
+import AbstractSyntaxTree from './typings/abstract-syntax-tree';
 import SlRule from './typings/sass-lint-rule';
 
 const gonzales = require('gonzales-pe-sl');

--- a/src/resolvers/indentation.ts
+++ b/src/resolvers/indentation.ts
@@ -1,0 +1,83 @@
+import { truncate } from 'fs';
+import BaseResolver from './base-resolver';
+import AbstractSyntaxTree, { TreeNode } from './typings/abstract-syntax-tree';
+import SlRule from './typings/sass-lint-rule';
+
+const gonzales = require('gonzales-pe-sl');
+
+export default class Indentation extends BaseResolver {
+  private _depth: number;
+  private _openingBraceRegex: RegExp;
+  private _closingBraceRegex: RegExp;
+  private _newLineDelimiter: string;
+
+  constructor(ast: AbstractSyntaxTree, parser: SlRule) {
+    super(ast, parser);
+    this._depth = 0;
+    this._openingBraceRegex = /{|\(/g;
+    this._closingBraceRegex = /}|\)/g;
+    this._newLineDelimiter = '\n';
+  }
+
+  public fix(): AbstractSyntaxTree {
+    const { ast } = this;
+
+    if (ast.syntax === 'sass') {
+      return ast; // TODO: Support sass files
+    }
+
+    const rawContent = ast.toString();
+    const resolvedContent = rawContent
+      .split(this._newLineDelimiter)
+      .map(line => this.visit(line))
+      .join(this._newLineDelimiter);
+
+    const resolvedAst = gonzales.parse(resolvedContent, {
+      syntax: ast.syntax,
+    });
+
+    return resolvedAst;
+  }
+
+  private visit(line: string): string {
+    if (this.isEmpty(line)) {
+      return line;
+    }
+    const openMatches = line.match(this._openingBraceRegex) || [];
+    const closeMatches = line.match(this._closingBraceRegex) || [];
+
+    if (closeMatches.length > openMatches.length) {
+      this._depth = Math.max(this._depth - 1, 0);
+    }
+
+    const resolvedLine = this.apply_indentation(line, this._depth);
+
+    if (openMatches.length > closeMatches.length) {
+      this._depth += 1;
+    }
+
+    return resolvedLine;
+  }
+
+  private apply_indentation(line: string, depth: number): string {
+    return `${this._spacingUnit.repeat(
+      depth * this.numSpaces,
+    )}${line.trimLeft()}`;
+  }
+
+  private isEmpty(line: string): boolean {
+    return line.trim().length === 0;
+  }
+
+  private tabEnabled(): boolean {
+    return this.parser.options.size === 'tab';
+  }
+
+  private get _spacingUnit(): string {
+    return this.tabEnabled() ? '\t' : ' ';
+  }
+
+  private get numSpaces(): number {
+    return this.tabEnabled() ? 1 : this.parser.options.size;
+  }
+}

--- a/src/resolvers/typings/abstract-syntax-tree.ts
+++ b/src/resolvers/typings/abstract-syntax-tree.ts
@@ -1,27 +1,30 @@
+type traversalCallback = (
+  node: TreeNode,
+  index?: number,
+  parent?: TreeNode,
+) => void;
+type traversalCallbackWithDepth = (
+  node: TreeNode,
+  index?: number,
+  parent?: TreeNode,
+  depth?: number,
+) => void;
+
 export default interface AbstractSyntaxTree {
   syntax: string;
+  length: number;
   is(nodeType: string): boolean;
-  traverse(
-    callback: (node: TreeNode, index?: number, parent?: TreeNode) => void,
-  ): void;
-  traverseByType(
-    nodeType: string,
-    callback: (node: TreeNode, index?: number, parent?: TreeNode) => void,
-  ): void;
-  traverseByTypes(
-    nodeTypes: string[],
-    callback: (node: TreeNode, index?: number, parent?: TreeNode) => void,
-  ): void;
+  get(index: number): AbstractSyntaxTree | null;
+  traverse(callback: traversalCallbackWithDepth): void;
+  traverseByType(nodeType: string, callback: traversalCallback): void;
+  traverseByTypes(nodeTypes: string[], callback: traversalCallback): void;
   removeChild(index: number): TreeNode;
 };
 
 export interface TreeNode extends AbstractSyntaxTree {
   type: string;
   content: any;
-  forEach(
-    nodeType: string,
-    callback: (node: TreeNode, index?: number, parent?: TreeNode) => void,
-  ): void;
+  forEach(nodeType: string, callback: traversalCallback): void;
   first(nodeType?: string): TreeNode;
   toString(): string;
 }

--- a/test/sass/indentation.scss
+++ b/test/sass/indentation.scss
@@ -1,0 +1,175 @@
+$foo: (
+  'foo': 'bar',
+  'bar': (
+    'foo': 'bze'
+  )
+);
+
+.parent {
+  &__child {
+    p::first-line {
+      content: '';
+    }
+  }
+}
+
+.foo,
+.bar {
+  content: 'bar';
+
+    content: 'baz';
+content: 'bar';
+
+  @include breakpoint(500) {
+    content: 'baz';
+  content: 'qux';
+  }
+
+  @include mixin-extra {
+    content: 'baz';
+    content: 'qux';
+  }
+
+  @include mixin-empty-args() {
+    content: 'baz';
+    content: 'qux';
+  }
+
+    .qux {
+      content: 'bar';
+    }
+
+  @if (1 == 1) {
+    content: 'foo';
+  }
+}
+
+@mixin bar {
+    content: 'bar';
+	content: 'baz';
+}
+
+.color {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+$colors: (
+  base: (
+    red: #fff,
+    blue: #fff
+  ),
+  text: (
+    default: #fff,
+    light: (
+      brap: #987
+    ),
+    not: (
+      test: #fff
+    )
+  )
+);
+
+.multilineprops {
+  background: transparent linear-gradient(
+    to bottom,
+      #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  );
+}
+
+.multilineprops-extra {
+  background: transparent linear-gradient(to bottom, #ff0000 0%, #00ff00 40%, #0000ff 40%);
+}
+
+// Top-level mixin
+@include hello(
+  $foo,
+  $bar,
+  $baz
+);
+
+.foo {
+  // Nested Mixin
+  @include hello(
+    $foo,
+    $bar,
+    $baz
+  );
+
+  // CSS built-in function
+  background: transparent linear-gradient(
+    to bottom,
+    #ff0000 0%,
+    #00ff00 40%,
+    #0000ff 40%
+  );
+
+  // User-defined function
+  content: goodbye(
+    $foo,
+    $bar
+  );
+}
+
+@function cp($target, $container) {
+  @return calc-percent($target, $container);
+}
+
+// Issue #426 - Unexpected indenting enforcement on multiline rules
+@mixin hidpi-background-image($filename, $background-size: 'mixed', $extension: png) {
+  background-image: url('../images/#{$filename}.#{$extension}');
+  @if ($background-size != 'mixed') {
+    background-size: $background-size;
+  }
+  @media (min--moz-device-pixel-ratio: 1.3),
+    (-o-min-device-pixel-ratio: 2.6/2),
+    (-webkit-min-device-pixel-ratio: 1.3),
+      (min-device-pixel-ratio: 1.3),
+    (min-resolution: 1.3dppx) {
+      background-image: url('../images/#{$filename}@2x.#{$extension}');
+        color: red;
+    }
+}
+
+@media (max-width: 800px), (max-height: 600px) {
+  #unit {
+    margin: 16px;
+  }
+}
+
+@media (max-width: 800px), (max-height: 600px) {
+    #unit {
+      margin: 16px;
+    }
+}
+
+// Issue #783 and issue #779 - at-rule throws off indentation of maps etc
+
+@import 'echo-base/defaults/breakpoints';
+
+$textsizes: (
+  xs: (
+    s: 10px,
+    m: 10px
+  ),
+  s: (
+    s: 12px,
+      m: 13px
+  ),
+);
+
+@function em($pixels, $context: $font-size-base) {
+  @return #{($pixels / $context)}rem;
+}
+
+$textsizes: (
+  xs: (
+    s: 10px,
+      m: 10px
+  ),
+  s: (
+    s: 12px,
+    m: 13px
+  ),
+);

--- a/test/src/resolvers/hex-notation.ts
+++ b/test/src/resolvers/hex-notation.ts
@@ -88,10 +88,7 @@ describe('hex-notation', () => {
         resolve(filename, options, (_, __, resolvedTree) => {
           const preResolve = lint(filename, options);
           const postResolve = detect(resolvedTree.toString(), 'sass', options);
-          require('fs').writeFileSync(
-            'test/sass/hex-notation-1.sass',
-            resolvedTree.toString(),
-          );
+
           expect(preResolve.warningCount).toBe(6);
           expect(postResolve.warningCount).toBe(0);
           done();

--- a/test/src/resolvers/indentation.ts
+++ b/test/src/resolvers/indentation.ts
@@ -1,7 +1,5 @@
 import resolve, { detect, lint } from '@test/helpers/resolve';
 
-const fs = require('fs');
-
 describe('indentation', () => {
   describe('scss', () => {
     const options = { indentation: 1 };

--- a/test/src/resolvers/indentation.ts
+++ b/test/src/resolvers/indentation.ts
@@ -1,0 +1,19 @@
+import resolve, { detect, lint } from '@test/helpers/resolve';
+
+const fs = require('fs');
+
+describe('indentation', () => {
+  describe('scss', () => {
+    const options = { indentation: 1 };
+    it('resolves', done => {
+      const filename = 'test/sass/indentation.scss';
+      resolve(filename, options, (_, __, resolvedTree) => {
+        const preResolve = lint(filename, options);
+        const postResolve = detect(resolvedTree.toString(), 'scss', options);
+        expect(preResolve.warningCount).toBe(14);
+        expect(postResolve.warningCount).toBe(6);
+        done();
+      });
+    });
+  });
+});

--- a/test/src/resolvers/indentation.ts
+++ b/test/src/resolvers/indentation.ts
@@ -9,7 +9,7 @@ describe('indentation', () => {
         const preResolve = lint(filename, options);
         const postResolve = detect(resolvedTree.toString(), 'scss', options);
         expect(preResolve.warningCount).toBe(14);
-        expect(postResolve.warningCount).toBe(6);
+        expect(postResolve.warningCount).toBe(0);
         done();
       });
     });


### PR DESCRIPTION
Work in progress 
- Maybe support multiline definitions for  @ queries in given format

Closes #18 

Example: 
```scss
@media (min--moz-device-pixel-ratio: 1.3),
  (-o-min-device-pixel-ratio: 2.6/2),
  (-webkit-min-device-pixel-ratio: 1.3),
  (min-device-pixel-ratio: 1.3),
  (min-resolution: 1.3dppx) {
    content: 'baz';
}
```

The desired effect of listing properties (not @) is like such:
```scss
.foo,
.bar {
  content: 'baz';
}
```

