### PR TITLE
fix(bug): multiple resolvers

### DIFF
--- a/src/sass-lint-auto-fix.ts
+++ b/src/sass-lint-auto-fix.ts
@@ -83,9 +83,9 @@ export function autoFixSassFactory(config: ConfigOpts) {
                   `Running resolver "${name}" on "${filename}"`,
                 );
 
-                const resolvedTree = resolver.fix();
+                ast = resolver.fix();
                 yield {
-                  ast: resolvedTree,
+                  ast,
                   filename,
                   rule,
                 };


### PR DESCRIPTION
This is working under the assumption that resolver.fix won't return a broken tree.

In the future, if this is problematic - at each stage convert the and back to ast.