### PR TITLE
fix(build): adds skip_cleanup to docs job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       script: yarn docs
       deploy:
         provider: pages
-        cleanup: false
+        skip_cleanup: true
         github-token: $GH_TOKEN
         local-dir: docs
         on:


### PR DESCRIPTION
Cleanup happens before push to gh-pages, this prevents cleanup happening too early.