### PR TITLE
Add support for ordering css variables declaration

### DIFF
--- a/src/resolvers/property-sort-order.ts
+++ b/src/resolvers/property-sort-order.ts
@@ -23,7 +23,7 @@ export default class PropertySortOrder extends BaseResolver {
       const collectedDecl: SortNode[] = [];
       const matchingIndices: number[] = [];
       block.forEach('declaration', (declaration: Node, index: number) => {
-        const prop = declaration.first('property');
+        const prop = declaration.first('property') || declaration.first('customProperty');
         if (prop) {
           let nodeContainingName = prop.first('ident');
 


### PR DESCRIPTION
Css variables are not property declarations but considered customProperties by the parser adding this allows for custom properties like
```
--my-var: #123;
```
To be sorted as well