### PR TITLE
fix(exit code): the process doesn't exit with the correct exit code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ const { version } = require('../package.json');
       SentryService.reportIncident(error);
     }
     logger.error(error);
+    process.exitCode = 1;
   });
 
   process.on('uncaughtException', (error: Error) => {
@@ -64,7 +65,7 @@ const { version } = require('../package.json');
       SentryService.reportIncident(error);
     }
     logger.error(error);
-    process.exit(1);
+    process.exitCode = 1;
   });
 
   const pattern = program.args[0];


### PR DESCRIPTION
As a result when lint fails during a CI the job isn't considered failing