### PR TITLE
FIX: Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.…

### DIFF
--- a/src/helpers/get-config.ts
+++ b/src/helpers/get-config.ts
@@ -3,7 +3,7 @@ import merge from 'merge';
 import { ConfigOpts } from '@src/types';
 import { cosmiconfigSync as configSync } from 'cosmiconfig';
 import { readFileSync } from 'fs';
-import { safeLoad } from 'js-yaml';
+import { load } from 'js-yaml';
 import { LintOpts } from 'sass-lint';
 
 const defaultSearchPlaces = (moduleName: string) => [
@@ -17,7 +17,7 @@ const defaultSearchPlaces = (moduleName: string) => [
 
 export function loadDefaults(): ConfigOpts {
   // @ts-ignore
-  return safeLoad(
+  return load(
     readFileSync(require.resolve('../config/default.yml'), {
       encoding: 'utf8',
     }),


### PR DESCRIPTION
…load instead, which is now safe by default.

Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.